### PR TITLE
Update backups and set Rsync to use SSH

### DIFF
--- a/rsync-snapshot-backup/Dockerfile
+++ b/rsync-snapshot-backup/Dockerfile
@@ -5,7 +5,7 @@ FROM $BUILD_FROM
 ENV LANG C.UTF-8
 
 # Setup base
-RUN apk add --no-cache jq sshpass rsync
+RUN apk add --no-cache jq sshpass rsync openssh
 
 # Hass.io CLI
 ARG BUILD_ARCH

--- a/rsync-snapshot-backup/README.md
+++ b/rsync-snapshot-backup/README.md
@@ -19,6 +19,7 @@ Automatically create HomeAssistant snapshots and backup to remote server using `
 |`remote_directory`|Yes|The directory to put the backups on the remote server.<br />For example, on a Synology NAS, this would be the name of the Share.|
 |`snapshot_password`|No|If set, the snapshot will generate with a password.|
 |`keep_local_backup`|No|Control how many local backups you want to preserve.<br />- Default (`""`) is to keep no local backups created from this addon.<br />- If `all` then all local backups will be preserved.<br />- A positive integer will determine how many of the latest backups will be preserved. Note this will delete other local backups created outside this addon.|
+|`SSH_port`|Yes|SSH port used by `rsync` to send file to.|
 
 
 ## Example
@@ -46,6 +47,7 @@ rsync_password: 'some_password'
 remote_directory: 'homeassistant'
 snapshot_password: ''
 keep_local_backup: 2
+SSH_port: 22
 ```
 
 **Note**: _This is just an example, don't copy and past it! Create your own!_

--- a/rsync-snapshot-backup/config.json
+++ b/rsync-snapshot-backup/config.json
@@ -1,9 +1,9 @@
 {
   "name": "rsync Snapshot Backup",
-  "version": "1.0.1.1",
+  "version": "1.0.1.2",
   "slug": "rsync_snapshot_backup",
   "description": "Automatically create HomeAssistant snapshots and backup to remote server using rsync",
-  "url": "https://github.com/Baptiste-Leterrier/rsync-snapshot-backup/blob/master/README.md",
+  "url": "https://github.com/Sarabveer/rsync-snapshot-backup/tree/master/README.md",
   "startup": "once",
   "boot": "manual",
   "arch": [

--- a/rsync-snapshot-backup/config.json
+++ b/rsync-snapshot-backup/config.json
@@ -1,9 +1,9 @@
 {
   "name": "rsync Snapshot Backup",
-  "version": "1.0.1",
+  "version": "1.0.1.1",
   "slug": "rsync_snapshot_backup",
   "description": "Automatically create HomeAssistant snapshots and backup to remote server using rsync",
-  "url": "https://github.com/Sarabveer/rsync-snapshot-backup/tree/master/README.md",
+  "url": "https://github.com/Baptiste-Leterrier/rsync-snapshot-backup/blob/master/README.md",
   "startup": "once",
   "boot": "manual",
   "arch": [
@@ -22,7 +22,8 @@
     "rsync_password": "",
     "remote_directory": "",
     "snapshot_password": "",
-    "keep_local_backup": ""
+    "keep_local_backup": "",
+    "SSH_port": ""
   },
   "schema": {
     "rsync_host": "str",
@@ -30,6 +31,7 @@
     "rsync_password": "str",
     "remote_directory": "str",
     "snapshot_password": "str",
-    "keep_local_backup": "match(^(all|[+]?\\d*)$)"
+    "keep_local_backup": "match(^(all|[+]?\\d*)$)",
+    "SSH_port": "str"
   }
 }

--- a/rsync-snapshot-backup/run.sh
+++ b/rsync-snapshot-backup/run.sh
@@ -31,7 +31,7 @@ function create-local-backup {
 function copy-backup-to-remote {
 	rsyncurl="$RSYNC_USER@$RSYNC_HOST:$REMOTE_DIRECTORY"
 	echo "[INFO] Copying ${slug}.tar to ${REMOTE_DIRECTORY} on ${RSYNC_HOST} using rsync"
-	sshpass -e rsync -av -e "ssh -p ${SSH_PORT}" /backup/ $rsyncurl --ignore-existing
+	sshpass -e rsync -av -e "ssh -p ${SSH_PORT} -o StrictHostKeyChecking=no" /backup/ $rsyncurl --ignore-existing
 }
 
 function delete-local-backup {

--- a/rsync-snapshot-backup/run.sh
+++ b/rsync-snapshot-backup/run.sh
@@ -42,10 +42,10 @@ function delete-local-backup {
         echo "[INFO] Deleting local backup: ${slug}"
         ha backups remove "${slug}"
     else
-        last_date_to_keep=$(ha snapshots list --raw-json | jq .data.snapshots[].date | sort -r | \
+        last_date_to_keep=$(ha backups list --raw-json | jq .data.backups[].date | sort -r | \
             head -n "${KEEP_LOCAL_BACKUP}" | tail -n 1 | xargs date -D "%Y-%m-%dT%T" +%s --date )
 
-        ha backups list --raw-json | jq -c .data.snapshots[] | while read backup; do
+        ha backups list --raw-json | jq -c .data.backups[] | while read backup; do
             if [[ $(echo ${backup} | jq .date | xargs date -D "%Y-%m-%dT%T" +%s --date ) -lt ${last_date_to_keep} ]]; then
                 echo "[INFO] Deleting local backup: $(echo ${backup} | jq -r .slug)"
                 ha backups remove "$(echo ${backup} | jq -r .slug)"

--- a/rsync-snapshot-backup/run.sh
+++ b/rsync-snapshot-backup/run.sh
@@ -26,7 +26,7 @@ function create-local-backup {
 }
 
 function copy-backup-to-remote {
-	rsyncurl="$RSYNC_USER@$RSYNC_HOST::$REMOTE_DIRECTORY"
+	rsyncurl="$RSYNC_USER@$RSYNC_HOST:$REMOTE_DIRECTORY"
 	echo "[INFO] Copying ${slug}.tar to ${REMOTE_DIRECTORY} on ${RSYNC_HOST} using rsync"
 	sshpass -p $RSYNC_PASSWORD rsync -av /backup/ $rsyncurl --ignore-existing
 }

--- a/rsync-snapshot-backup/run.sh
+++ b/rsync-snapshot-backup/run.sh
@@ -5,12 +5,14 @@ CONFIG_PATH=/data/options.json
 
 # parse inputs from options
 RSYNC_HOST=$(jq --raw-output ".rsync_host" $CONFIG_PATH)
-SSHPASS=$(jq --raw-output ".rsync_user" $CONFIG_PATH)
+RSYNC_USER=$(jq --raw-output ".rsync_user" $CONFIG_PATH)
 RSYNC_PASSWORD=$(jq --raw-output ".rsync_password" $CONFIG_PATH)
 REMOTE_DIRECTORY=$(jq --raw-output ".remote_directory" $CONFIG_PATH)
 SNAPSHOT_PASSWORD=$(jq --raw-output '.snapshot_password' $CONFIG_PATH)
 KEEP_LOCAL_BACKUP=$(jq --raw-output '.keep_local_backup' $CONFIG_PATH)
 SSH_PORT=$(jq --raw-output '.SSH_port' $CONFIG_PATH)
+
+export SSHPASS=RSYNC_PASSWORD
 
 echo "[INFO] Starting rsync Snapshot Backup..."
 

--- a/rsync-snapshot-backup/run.sh
+++ b/rsync-snapshot-backup/run.sh
@@ -12,7 +12,7 @@ SNAPSHOT_PASSWORD=$(jq --raw-output '.snapshot_password' $CONFIG_PATH)
 KEEP_LOCAL_BACKUP=$(jq --raw-output '.keep_local_backup' $CONFIG_PATH)
 SSH_PORT=$(jq --raw-output '.SSH_port' $CONFIG_PATH)
 
-export SSHPASS=RSYNC_PASSWORD
+export SSHPASS=${RSYNC_PASSWORD}
 
 echo "[INFO] Starting rsync Snapshot Backup..."
 

--- a/rsync-snapshot-backup/run.sh
+++ b/rsync-snapshot-backup/run.sh
@@ -5,11 +5,12 @@ CONFIG_PATH=/data/options.json
 
 # parse inputs from options
 RSYNC_HOST=$(jq --raw-output ".rsync_host" $CONFIG_PATH)
-RSYNC_USER=$(jq --raw-output ".rsync_user" $CONFIG_PATH)
+SSHPASS=$(jq --raw-output ".rsync_user" $CONFIG_PATH)
 RSYNC_PASSWORD=$(jq --raw-output ".rsync_password" $CONFIG_PATH)
 REMOTE_DIRECTORY=$(jq --raw-output ".remote_directory" $CONFIG_PATH)
 SNAPSHOT_PASSWORD=$(jq --raw-output '.snapshot_password' $CONFIG_PATH)
 KEEP_LOCAL_BACKUP=$(jq --raw-output '.keep_local_backup' $CONFIG_PATH)
+SSH_PORT=$(jq --raw-output '.SSH_port' $CONFIG_PATH)
 
 echo "[INFO] Starting rsync Snapshot Backup..."
 
@@ -28,7 +29,7 @@ function create-local-backup {
 function copy-backup-to-remote {
 	rsyncurl="$RSYNC_USER@$RSYNC_HOST:$REMOTE_DIRECTORY"
 	echo "[INFO] Copying ${slug}.tar to ${REMOTE_DIRECTORY} on ${RSYNC_HOST} using rsync"
-	sshpass -p $RSYNC_PASSWORD rsync -av /backup/ $rsyncurl --ignore-existing
+	sshpass -e rsync -av -e "ssh -p ${SSH_PORT}" /backup/ $rsyncurl --ignore-existing
 }
 
 function delete-local-backup {


### PR DESCRIPTION
I updated the code to use " ha backups" as "ha snapshots" is deprecated.

Also I set rsync to use SSH as:

    A lot more people use rsync over SSH instead of configuring rsync daemon.
    Backups size can easily fit through SSH despite the lower speed to transfer.
